### PR TITLE
Send multiple messages from client.py with specific cross-cluster probability.

### DIFF
--- a/Multi-Paxos/client.py
+++ b/Multi-Paxos/client.py
@@ -6,6 +6,8 @@
 # the ability to propose new values in the multi-paxos chain.
 
 import sys
+import time
+import random
 
 from twisted.internet import reactor, defer, protocol
 
@@ -13,15 +15,52 @@ import config
 
 class ClientProtocol(protocol.DatagramProtocol):
 
-    def __init__(self, uid, new_value):
+    def __init__(self, uid, req_count, p_cross_cluster):
     	# TODO: fix later - A is hardcoded as leader proposer - all clients will write to server A's ip, port
         self.addr      = config.server[sys.argv[1]]
-        self.new_value = new_value
+        self.uid = uid
+        self.req_count = int(req_count)
+        self.p_cross_cluster = float(p_cross_cluster)
 
     def startProtocol(self):
-    	text = bytes('propose {0}'.format(self.new_value), 'utf-8')
-    	self.transport.write(text, self.addr)
+        message_interval = 0.2 # 200 ms
+        local_count = 0
+        cross_count = 0
+
+        for i in range(self.req_count):
+            sender_id, receiver_id = self.getRandomPeers()
+            message = 'propose {0}-{1}-{2}'.format(sender_id, receiver_id, random.randint(1,1000))
+            text = bytes(message, 'utf-8')
+            self.transport.write(text, self.addr)
+            time.sleep(message_interval)
+
+            # debug info
+            print(message)
+            if int(sender_id / 1000) == int(receiver_id / 1000):
+                local_count += 1
+            else:
+                cross_count += 1
+
+        print('local message: {0}, cross-cluster messages: {1}'.format(local_count, cross_count))
     	#reactor.stop()
+
+    def getRandomPeers(self):
+        cluster_count = len(config.peers[0])
+        per_cluster = len(config.peers[0][1])
+
+        peer_1 = int(self.uid) + random.randint(1, per_cluster)
+
+        roll = random.random()
+        if roll < self.p_cross_cluster:
+            cluster_id = random.randrange(1000, cluster_count * 1000, 1000)
+            # wrap around (also, avoiding zero)
+            cluster_id = ((int(self.uid) + cluster_id - 1000) % (cluster_count * 1000)) + 1000
+
+            peer_2 = cluster_id + random.randint(1, per_cluster)
+        else:
+            peer_2 = int(self.uid) + random.randint(1, per_cluster)
+        return (peer_1, peer_2)
+
     def datagramReceived(self, packet0, from_addr):
         packet = str(packet0, 'utf-8')
         try:
@@ -38,13 +77,13 @@ class ClientProtocol(protocol.DatagramProtocol):
             traceback.print_exc()
 
 
-if len(sys.argv) != 3 or not sys.argv[1] in config.server:
+if len(sys.argv) != 4 or not sys.argv[1] in config.server:
     print('python client.py <id of lead proposer: 1000, 2000, 3000 or 4000> <sndr id>-,rcvr id>-<amount>')
     sys.exit(1)
 
     
 def main():
-    reactor.listenUDP(config.client[sys.argv[1]][1],ClientProtocol(sys.argv[1], sys.argv[2]))
+    reactor.listenUDP(config.client[sys.argv[1]][1],ClientProtocol(sys.argv[1], sys.argv[2], sys.argv[3]))
 
     
 reactor.callWhenRunning(main)


### PR DESCRIPTION
**Parameter changes:**

Removed the `new_value` parameter from client.py parameters. It will now be generated randomly for each message.
Added two new parameters:
- `req_count`: The number of request generated by the client.
- `p_cross_cluster`: the probability of generating a cross-cluster request.

Example:
`python3 client.py 1000 250 0.2`
generates 250 messages with a 20 percent cross-cluster probability.

**Code changes:**

Generate messages in a loop.
The interval between each message is now hardcoded as 200ms.

Defined the `getRandomPeers` function. `peer_1` is always selected from the same cluster as client. `peer_2` cluster is selected based on the `p_cross_cluster` probability.